### PR TITLE
Support dynamic specification of reporter type map info

### DIFF
--- a/src/exometer_report.erl
+++ b/src/exometer_report.erl
@@ -155,6 +155,8 @@
     add_reporter/2,
     remove_reporter/1,
     terminate_reporter/1,
+    call_reporter/2,
+    cast_reporter/2,
     setopts/3,
     new_entry/1
    ]).
@@ -254,7 +256,7 @@ start_link() ->
 -spec subscribe(module(), metric(), datapoint(), interval()) -> 
     ok | not_found | unknown_reporter.
 subscribe(Reporter, Metric, DataPoint, Interval) ->
-    subscribe(Reporter, Metric, DataPoint, Interval, undefined).
+    subscribe(Reporter, Metric, DataPoint, Interval, []).
 
 -spec subscribe(module(), metric(), datapoint(), interval(), extra()) -> 
     ok | not_found | unknown_reporter.
@@ -303,6 +305,22 @@ add_reporter(Reporter, Options) ->
 
 remove_reporter(Reporter) ->
     call({remove_reporter, Reporter}).
+
+call_reporter(Reporter, Msg) ->
+    case lists:keyfind(Reporter, 1, list_reporters()) of
+        {_, Pid} ->
+            exometer_proc:call(Pid, Msg);
+        false ->
+            {error, {no_such_reporter, Reporter}}
+    end.
+
+cast_reporter(Reporter, Msg) ->
+    case lists:keyfind(Reporter, 1, list_reporters()) of
+        {_, Pid} ->
+            exometer_proc:cast(Pid, Msg);
+        false ->
+            {error, {no_such_reporter, Reporter}}
+    end.
 
 setopts(Metric, Options, Status) ->
     call({setopts, Metric, Options, Status}).


### PR DESCRIPTION
When adding a subscription dynamically, there hasn't been support
for updating the type maps in the reporters. Two alternatives have
been added to enable dynamic management of type mapping.
1. Add {report_type, Type} in Extra when adding the subscription.
   This information will override whatever information is in the
   type map.
2. Wildcard type maps
   It's now possible to use a wildcard pattern in a type_map entry.
   E.g. {[my_app, counters, '_'|'_'], counter}.
   The function exometer_util:report_type(Key, Extra, TypeMap)
   searches the type map from the top down, until it finds a
   pattern that matches the key.
