### PR TITLE
Fix converting of 'mean' value depending on value type

### DIFF
--- a/src/exometer_report_snmp.erl
+++ b/src/exometer_report_snmp.erl
@@ -509,8 +509,10 @@ snmp_value(Name, Dp, Value) ->
     case {Mod, Type, Dp} of
         {exometer, T, _} when T == counter; T == fast_counter ->
             {value, Value};
-        {exometer_histogram, histogram, mean} ->
+        {exometer_histogram, histogram, mean} when is_float(Value) ->
             {value, erlang:float_to_list(Value)};
+        {exometer_histogram, histogram, mean} when is_integer(Value) ->
+            {value, erlang:integer_to_list(Value)};
         {exometer_histogram, histogram, _ } ->
             {value, Value};
         _ ->


### PR DESCRIPTION
Can't export histogram via SNMP if 'mean' value is not float.

This patch checks the value's type of 'mean' value and apply appropriate function to convert it to list

Metric values:

```
{[some, metric],
  [{n,0},
   {mean,0},
   {min,0},
   {max,0},
   {median,0},
   {50,0},
   {75,0},
   {90,0},
   {95,0},
   {99,0},
   {999,0}]}
```

Output from error log:

```
2014-03-11 14:30:39.719 [error] <0.101.0> ** User error: Got {'EXIT',{badarg,[{erlang,float_to_list,[0],[]},{exometer_report_snmp,snmp_value,3,[{file,[115,114,99,47,101,120,111,109,101,116,101,114,95,114,101,112,111,114,116,95,115,110,109,112,46,101,114,108]},{line,510}]},{snmpa_agent,try_get_instance,2,[{file,[115,110,109,112,97,95,97,103,101,110,116,46,101,114,108]},{line,3350}]},{snmpa_agent,next_loop_varbinds,6,[{file,[115,110,109,112,97,95,97,103,101,110,116,46,101,114,108]},{line,3160}]},{snmpa_agent,process_pdu,5,[{file,[115,110,109,112,97,95,97,103,101,110,116,46,101,114,108]},{line,2552}]},{snmpa_agent,do_handle_pdu,8,[{file,[115,110,109,112,97,95,97,103,101,110,116,46,101,114,108]},{line,1965}]},{snmpa_agent,handle_snmp_pdu,8,[{file,[115,110,109,112,97,95,97,103,101,110,116,46,101,114,108]},{line,1894}]},{snmpa_agent,handle_info,2,[{file,[115,110,109,112,97,95,97,103,101,110,116,46,101,114,108]},{line,812}]}]}} from {exometer_report_snmp,snmp_operation,[{[busycall,recall,a_b_h],mean}]}. ({asn1_type,'OCTET STRING',0,64,[],true,'OCTET STRING'..
```
