### PR TITLE
Fix graphite formatting

### DIFF
--- a/src/exometer_report_graphite.erl
+++ b/src/exometer_report_graphite.erl
@@ -75,7 +75,6 @@ exometer_report(Probe, DataPoint, _Extra, Value, #st{socket = Sock,
                                                     prefix = Prefix} = St) ->
     Line = [prefix(Prefix, APIKey), ".", name(Probe, DataPoint), " ",
             value(Value), " ", timestamp(), $\n],
-    io:fwrite("L = ~s~n", [Line]),
     case gen_tcp:send(Sock, Line) of
         ok ->
             {ok, St};


### PR DESCRIPTION
- Converts a list of atoms to a list of dot separated lists.
- Removes a debugging output. 
