### PR TITLE
Fix uniform percentiles

### DIFF
--- a/src/exometer_uniform.erl
+++ b/src/exometer_uniform.erl
@@ -72,7 +72,11 @@ probe_get_value(DataPoints, St) ->
 			     {0, 0.0, []}, St#st.ets_ref),
 
     Sorted = lists:sort(Lst),
-    Results = exometer_util:get_statistics2(Length, Sorted, Total/Length),
+    Mean = case Length of
+               0 -> 0.0;
+               N -> Total/N
+           end,
+    Results = exometer_util:get_statistics2(Length, Sorted, Mean),
     {ok, [get_dp(Results, DataPoint) || DataPoint <- DataPoints]}.
 
 get_dp(L, D) ->


### PR DESCRIPTION
Percentiles in uniform metrics return the number of entries below that percentile, not the value itself.
I wonder if there is any reason for this, otherwise they should be computed as the histogram ones.

Current implementation:

```
12> exometer:new([c], uniform).                                          
ok
13> [exometer:update([c], X) || X  <- lists:seq(500, 510)].              
[ok,ok,ok,ok,ok,ok,ok,ok,ok,ok,ok]
14> exometer:get_values([c]).
[{[c],
  [{min,500},
   {max,510},
   {median,505},
   {mean,505.0},
   {50,6},
   {75,8},
   {90,10},
   {95,10},
   {99,11},
   {999,11}]}]
```

Proposed implementation:

```
17> exometer:get_values([c]).
[{[c],
  [{min,500},
   {max,510},
   {median,505},
   {mean,505.0},
   {50,505},
   {75,507},
   {90,509},
   {95,509},
   {99,510},
   {999,510}]}]
```
