### PR TITLE
Fix probe delete

### DIFF
--- a/src/exometer_probe.erl
+++ b/src/exometer_probe.erl
@@ -569,7 +569,7 @@ handle_msg(Msg, St) ->
             exometer_proc:stop();
 
         Other ->
-            process_probe_noreply(St, Module:probe_handle_msg(Other, St))
+            process_probe_noreply(St, Module:probe_handle_msg(Other, St#st.mod_state))
     end.
 
 


### PR DESCRIPTION
- Give mod_state to the probe callback

exometer:delete(Stat) returns ok due to the exometer_probe:delete/1 cast. However, a crash is reported from the probe callback when the internal state of exometer_probe is received, instead of the state of the probe itself (uniform in this example).

```
2014-04-03 15:29:45 =CRASH REPORT====
  crasher:
    initial call: exometer_proc:-spawn_process/2-fun-0-/0
    pid: <0.192.0>
    registered_name: []
    exception error: {{badrecord,st},[{exometer_uniform,probe_terminate,1,[{file,"src/exometer_uniform.erl"},{line,65}]},{exometer_probe,handle_msg,2,[{file,"src/exometer_probe.erl"},{line,564}]},{exometer_probe,loop,1,[{file,"src/exometer_probe.erl"},{line,509}]},{proc_lib,init_p,3,[{file,"proc_lib.erl"},{line,224}]}]}
    ancestors: [exometer_admin,exometer_sup,<0.140.0>]
    messages: []
    links: []
    dictionary: [{random_seed,{1397,20181,28094}}]
    trap_exit: false
    status: running
    heap_size: 46422
    stack_size: 27
    reductions: 141
  neighbours:
```
