### PR TITLE
added exometer_report_lager.erl

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
 
-__Version:__ Mar 20 2014 20:42:23
+__Version:__ Apr 20 2014 18:50:46
 
 __Authors:__ Ulf Wiger ([`ulf.wiger@feuerlabs.com`](mailto:ulf.wiger@feuerlabs.com)), Magnus Feuer ([`magnus.feuer@feuerlabs.com`](mailto:magnus.feuer@feuerlabs.com)).
 
@@ -1005,6 +1005,7 @@ Please see @see exometer_report documentation for details.
 <tr><td><a href="https://github.com/Feuerlabs/exometer/blob/master/doc/exometer_report.md" class="module">exometer_report</a></td></tr>
 <tr><td><a href="https://github.com/Feuerlabs/exometer/blob/master/doc/exometer_report_collectd.md" class="module">exometer_report_collectd</a></td></tr>
 <tr><td><a href="https://github.com/Feuerlabs/exometer/blob/master/doc/exometer_report_graphite.md" class="module">exometer_report_graphite</a></td></tr>
+<tr><td><a href="https://github.com/Feuerlabs/exometer/blob/master/doc/exometer_report_lager.md" class="module">exometer_report_lager</a></td></tr>
 <tr><td><a href="https://github.com/Feuerlabs/exometer/blob/master/doc/exometer_report_riak.md" class="module">exometer_report_riak</a></td></tr>
 <tr><td><a href="https://github.com/Feuerlabs/exometer/blob/master/doc/exometer_report_snmp.md" class="module">exometer_report_snmp</a></td></tr>
 <tr><td><a href="https://github.com/Feuerlabs/exometer/blob/master/doc/exometer_report_statsd.md" class="module">exometer_report_statsd</a></td></tr>

--- a/doc/edoc-info
+++ b/doc/edoc-info
@@ -1,10 +1,10 @@
-%% encoding: UTF-8
 {application,exometer}.
 {packages,[]}.
 {modules,[exometer,exometer_admin,exometer_cache,exometer_cpu,
           exometer_duration,exometer_entry,exometer_folsom,exometer_function,
           exometer_histogram,exometer_igor,exometer_netlink,exometer_probe,
           exometer_proc,exometer_report,exometer_report_collectd,
-          exometer_report_graphite,exometer_report_riak,exometer_report_snmp,
-          exometer_report_statsd,exometer_report_tty,exometer_slide,
-          exometer_slot_slide,exometer_spiral,exometer_uniform,exometer_util]}.
+          exometer_report_graphite,exometer_report_lager,exometer_report_riak,
+          exometer_report_snmp,exometer_report_statsd,exometer_report_tty,
+          exometer_slide,exometer_slot_slide,exometer_spiral,exometer_uniform,
+          exometer_util]}.

--- a/doc/exometer_report_lager.md
+++ b/doc/exometer_report_lager.md
@@ -1,0 +1,134 @@
+
+
+# Module exometer_report_lager #
+* [Description](#description)
+* [Function Index](#index)
+* [Function Details](#functions)
+
+
+Exometer reporter for lager backend.
+__Behaviours:__ [`exometer_report`](exometer_report.md).
+<a name="description"></a>
+
+## Description ##
+
+
+
+This reporter emits messages to the lager logging backend,
+at a reporting level chosen by the user (default: `notice`).
+
+
+
+To change the reporting level, pass on the option `{level, Level}`.
+
+
+Example:
+
+```erlang
+
+  Eshell V5.9.2  (abort with ^G)
+  1> exometer:start().
+  17:41:14.078 [info] Application lager started on node nonode@nohost
+  ok
+  17:41:14.125 [info] Starting reporters with []
+  17:41:14.125 [info] Application exometer started on node nonode@nohost
+  2> lager:set_loglevel(lager_console_backend,notice).
+  ok
+  3> exometer:new([c], counter).
+  ok
+  4> exometer:update([c], 2).
+  ok
+  5> exometer_report:add_reporter(
+         exometer_report_lager,[{type_map,[{'_',integer}]}]).
+  ok
+  6> exometer_report:subscribe(exometer_report_lager,[c],[value],10000).
+  ok
+  17:42:47.496 [notice] exometer_report_lager: c_value 1398008567:2 (integer)
+  17:42:57.498 [notice] exometer_report_lager: c_value 1398008577:2 (integer)
+  17:43:07.499 [notice] exometer_report_lager: c_value 1398008587:2 (integer)
+  7> exometer:update([c], 2).
+  ok
+  17:43:17.501 [notice] exometer_report_lager: c_value 1398008597:4 (integer)
+```
+<a name="index"></a>
+
+## Function Index ##
+
+
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#exometer_call-3">exometer_call/3</a></td><td></td></tr><tr><td valign="top"><a href="#exometer_cast-2">exometer_cast/2</a></td><td></td></tr><tr><td valign="top"><a href="#exometer_info-2">exometer_info/2</a></td><td></td></tr><tr><td valign="top"><a href="#exometer_init-1">exometer_init/1</a></td><td></td></tr><tr><td valign="top"><a href="#exometer_newentry-2">exometer_newentry/2</a></td><td></td></tr><tr><td valign="top"><a href="#exometer_report-5">exometer_report/5</a></td><td></td></tr><tr><td valign="top"><a href="#exometer_setopts-4">exometer_setopts/4</a></td><td></td></tr><tr><td valign="top"><a href="#exometer_subscribe-5">exometer_subscribe/5</a></td><td></td></tr><tr><td valign="top"><a href="#exometer_terminate-2">exometer_terminate/2</a></td><td></td></tr><tr><td valign="top"><a href="#exometer_unsubscribe-4">exometer_unsubscribe/4</a></td><td></td></tr></table>
+
+
+<a name="functions"></a>
+
+## Function Details ##
+
+<a name="exometer_call-3"></a>
+
+### exometer_call/3 ###
+
+`exometer_call(Unknown, From, St) -> any()`
+
+
+<a name="exometer_cast-2"></a>
+
+### exometer_cast/2 ###
+
+`exometer_cast(Unknown, St) -> any()`
+
+
+<a name="exometer_info-2"></a>
+
+### exometer_info/2 ###
+
+`exometer_info(Unknown, St) -> any()`
+
+
+<a name="exometer_init-1"></a>
+
+### exometer_init/1 ###
+
+`exometer_init(Opts) -> any()`
+
+
+<a name="exometer_newentry-2"></a>
+
+### exometer_newentry/2 ###
+
+`exometer_newentry(Entry, St) -> any()`
+
+
+<a name="exometer_report-5"></a>
+
+### exometer_report/5 ###
+
+`exometer_report(Metric, DataPoint, Extra, Value, St) -> any()`
+
+
+<a name="exometer_setopts-4"></a>
+
+### exometer_setopts/4 ###
+
+`exometer_setopts(Metric, Options, Status, St) -> any()`
+
+
+<a name="exometer_subscribe-5"></a>
+
+### exometer_subscribe/5 ###
+
+`exometer_subscribe(Metric, DataPoint, Extra, Interval, St) -> any()`
+
+
+<a name="exometer_terminate-2"></a>
+
+### exometer_terminate/2 ###
+
+`exometer_terminate(X1, X2) -> any()`
+
+
+<a name="exometer_unsubscribe-4"></a>
+
+### exometer_unsubscribe/4 ###
+
+`exometer_unsubscribe(Metric, DataPoint, Extra, St) -> any()`
+
+

--- a/src/exometer_report_lager.erl
+++ b/src/exometer_report_lager.erl
@@ -1,0 +1,162 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%%   This Source Code Form is subject to the terms of the Mozilla Public
+%%   License, v. 2.0. If a copy of the MPL was not distributed with this
+%%   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Exometer reporter for lager backend
+%%
+%% This reporter emits messages to the lager logging backend,
+%% at a reporting level chosen by the user (default: `notice').
+%%
+%% To change the reporting level, pass on the option `{level, Level}'.
+%%
+%% Example:
+%% <pre lang="erlang">
+%% Eshell V5.9.2  (abort with ^G)
+%% 1&gt; exometer:start().
+%% 17:41:14.078 [info] Application lager started on node nonode@nohost
+%% ok
+%% 17:41:14.125 [info] Starting reporters with []
+%% 17:41:14.125 [info] Application exometer started on node nonode@nohost
+%%
+%% 2&gt; lager:set_loglevel(lager_console_backend,notice).
+%% ok
+%% 3&gt; exometer:new([c], counter).
+%% ok
+%% 4&gt; exometer:update([c], 2).
+%% ok
+%% 5&gt; exometer_report:add_reporter(
+%%        exometer_report_lager,[{type_map,[{'_',integer}]}]).
+%% ok
+%% 6&gt; exometer_report:subscribe(exometer_report_lager,[c],[value],10000).
+%% ok
+%% 17:42:47.496 [notice] exometer_report_lager: c_value 1398008567:2 (integer)
+%% 17:42:57.498 [notice] exometer_report_lager: c_value 1398008577:2 (integer)
+%% 17:43:07.499 [notice] exometer_report_lager: c_value 1398008587:2 (integer)
+%% 7&gt; exometer:update([c], 2).
+%% ok
+%% 17:43:17.501 [notice] exometer_report_lager: c_value 1398008597:4 (integer)
+%% </pre>
+%% @end
+
+-module(exometer_report_lager).
+
+-behaviour(exometer_report).
+
+-export(
+   [
+    exometer_init/1,
+    exometer_info/2,
+    exometer_cast/2,
+    exometer_call/3,
+    exometer_report/5,
+    exometer_subscribe/5,
+    exometer_unsubscribe/4,
+    exometer_newentry/2,
+    exometer_setopts/4,
+    exometer_terminate/2
+   ]).
+
+-include_lib("exometer/include/exometer.hrl").
+-include("log.hrl").
+
+-define(SERVER, ?MODULE).
+%% calendar:datetime_to_gregorian_seconds({{1970,1,1},{0,0,0}}).
+-define(UNIX_EPOCH, 62167219200).
+
+-record(st, {type_map = [], level = notice}).
+
+%%%===================================================================
+%%% exometer_report callback API
+%%%===================================================================
+
+exometer_init(Opts) ->
+    ?info("~p(~p): Starting~n", [?MODULE, Opts]),
+    St0 = #st{},
+    TypeMap = proplists:get_value(type_map, Opts, St0#st.type_map),
+    Level = proplists:get_value(level, Opts, St0#st.level),
+    {ok, St0#st{type_map = TypeMap, level = Level}}.
+
+exometer_subscribe(_Metric, _DataPoint, _Extra, _Interval, St) ->
+    {ok, St}.
+
+exometer_unsubscribe(_Metric, _DataPoint, _Extra, St) ->
+    {ok, St}.
+
+%% Invoked through the remote_exometer() function to
+%% send out an update.
+exometer_report(Metric, DataPoint, Extra, Value, #st{level = Level} = St)  ->
+    ?debug("Report metric ~p_~p = ~p~n", [Metric, DataPoint, Value]),
+    %% Report the value and setup a new refresh timer.
+    Key = Metric ++ [DataPoint],
+    Type = case exometer_util:report_type(Key, Extra, St#st.type_map) of
+               {ok, T} -> T;
+               error   -> unknown
+           end,
+    Str = [?MODULE_STRING, ": ", name(Metric, DataPoint), $\s,
+           timestamp(), ":", value(Value), io_lib:format(" (~w)", [Type]), $\n],
+    log(Level, Str),
+    {ok, St}.
+
+exometer_call(Unknown, From, St) ->
+    ?info("Unknown call ~p from ~p", [Unknown, From]),
+    {ok, St}.
+
+exometer_cast(Unknown, St) ->
+    ?info("Unknown cast: ~p", [Unknown]),
+    {ok, St}.
+
+exometer_info(Unknown, St) ->
+    ?info("Unknown info: ~p", [Unknown]),
+    {ok, St}.
+
+exometer_newentry(_Entry, St) ->
+    {ok, St}.
+
+exometer_setopts(_Metric, _Options, _Status, St) ->
+    {ok, St}.
+
+exometer_terminate(_, _) ->
+    ignore.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+%% Add metric and datapoint within metric
+name(Metric, DataPoint) ->
+    metric_to_string(Metric) ++ "_" ++ atom_to_list(DataPoint).
+
+metric_to_string([Final]) ->
+    metric_elem_to_list(Final);
+metric_to_string([H | T]) ->
+    metric_elem_to_list(H) ++ "_" ++ metric_to_string(T).
+
+metric_elem_to_list(E) when is_atom(E) ->
+    atom_to_list(E);
+metric_elem_to_list(E) when is_list(E); is_binary(E) ->
+    E;
+metric_elem_to_list(E) when is_integer(E) ->
+    integer_to_list(E).
+
+%% Add value, int or float, converted to list
+value(V) when is_integer(V) -> integer_to_list(V);
+value(V) when is_float(V)   -> io_lib:format("~f", [V]);
+value(_) -> "0".
+
+timestamp() ->
+    integer_to_list(unix_time()).
+
+unix_time() ->
+    datetime_to_unix_time(erlang:universaltime()).
+
+datetime_to_unix_time({{_,_,_},{_,_,_}} = DateTime) ->
+    calendar:datetime_to_gregorian_seconds(DateTime) - ?UNIX_EPOCH.
+
+log(Level, String) ->
+    lager:log(Level, self(), String).


### PR DESCRIPTION
The exometer_report_lager reporter is a slight modification of the tty reporter. It does the same kind of formatting, but emits a lager log entry (at a configurable level) instead of printing to the tty.

Note that lager doesn't allow custom log levels, so one of the existing log levels must be used. The default is 'notice', which is the level below 'debug'.
