### PR TITLE
Statsd Tags Enhancement

### DIFF
--- a/src/exometer_report_statsd.erl
+++ b/src/exometer_report_statsd.erl
@@ -114,7 +114,7 @@ exometer_terminate(_, _) ->
 line(Name, Value, Type, [])->
     [Name, ":", value(Value), "|", type(Type)];
 line(Name, Value, Type, Tags)->
-    [Name, ":", value(Value), "|", type(Type), "#", Tags].
+    [Name, ":", value(Value), "|", type(Type), "|", "#", Tags].
 
 
 get_opt(K, Opts, Def) ->


### PR DESCRIPTION
This PR allows metrics names to have a trailing number of tuples
which will be converted into a list of tags in the DataDog style. See
http://docs.datadoghq.com/guides/dogstatsd/ for more details.

This change is backward compatible with stock statsd.

Signed-off-by: Brian L. Troutwine brian.troutwine@adroll.com
