### PR TITLE
Fix template + option processing semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
 
-__Version:__ Oct 6 2014 17:32:30
+__Version:__ Oct 6 2014 19:27:39
 
 __Authors:__ Ulf Wiger ([`ulf.wiger@feuerlabs.com`](mailto:ulf.wiger@feuerlabs.com)), Magnus Feuer ([`magnus.feuer@feuerlabs.com`](mailto:magnus.feuer@feuerlabs.com)).
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,7 +4,7 @@
 
 Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
 
-__Version:__ Oct 6 2014 17:32:30
+__Version:__ Oct 6 2014 19:27:39
 
 __Authors:__ Ulf Wiger ([`ulf.wiger@feuerlabs.com`](mailto:ulf.wiger@feuerlabs.com)), Magnus Feuer ([`magnus.feuer@feuerlabs.com`](mailto:magnus.feuer@feuerlabs.com)).
 

--- a/doc/exometer.md
+++ b/doc/exometer.md
@@ -169,7 +169,7 @@ value() = any()
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#aggregate-2">aggregate/2</a></td><td>Aggregate datapoints of matching entries.</td></tr><tr><td valign="top"><a href="#create_entry-1">create_entry/1</a></td><td></td></tr><tr><td valign="top"><a href="#delete-1">delete/1</a></td><td>Delete the metric.</td></tr><tr><td valign="top"><a href="#ensure-3">ensure/3</a></td><td>Ensure that metric exists and is of given type.</td></tr><tr><td valign="top"><a href="#find_entries-1">find_entries/1</a></td><td>Find metrics based on a name prefix pattern.</td></tr><tr><td valign="top"><a href="#get_value-1">get_value/1</a></td><td>Fetch the current value of the metric.</td></tr><tr><td valign="top"><a href="#get_value-2">get_value/2</a></td><td></td></tr><tr><td valign="top"><a href="#get_values-1">get_values/1</a></td><td></td></tr><tr><td valign="top"><a href="#info-1">info/1</a></td><td>Returns a list of info items for Metric, see <a href="#info-2"><code>info/2</code></a>.</td></tr><tr><td valign="top"><a href="#info-2">info/2</a></td><td>Retrieves information about a metric.</td></tr><tr><td valign="top"><a href="#new-2">new/2</a></td><td>Equivalent to <a href="#new-3"><tt>new(Name, Type, [])</tt></a>.</td></tr><tr><td valign="top"><a href="#new-3">new/3</a></td><td>Create a new metrics entry.</td></tr><tr><td valign="top"><a href="#re_register-3">re_register/3</a></td><td>Create a new metrics entry, overwrite any old entry.</td></tr><tr><td valign="top"><a href="#register_application-0">register_application/0</a></td><td>Equivalent to <a href="#register_application-1"><tt>register_application(current_application())</tt></a>.</td></tr><tr><td valign="top"><a href="#register_application-1">register_application/1</a></td><td>Registers statically defined entries with exometer.</td></tr><tr><td valign="top"><a href="#reset-1">reset/1</a></td><td>Reset the metric.</td></tr><tr><td valign="top"><a href="#sample-1">sample/1</a></td><td>Tells the metric (mainly probes) to take a sample.</td></tr><tr><td valign="top"><a href="#select-1">select/1</a></td><td>Perform an <code>ets:select()</code> on the set of metrics.</td></tr><tr><td valign="top"><a href="#select-2">select/2</a></td><td>Perform an <code>ets:select()</code> with a Limit on the set of metrics.</td></tr><tr><td valign="top"><a href="#select_cont-1">select_cont/1</a></td><td>Equivalent to <a href="ets.md#select-1"><tt>ets:select(Cont)</tt></a>.</td></tr><tr><td valign="top"><a href="#select_count-1">select_count/1</a></td><td>Corresponds to <a href="ets.md#select_count-1"><code>ets:select_count/1</code></a>.</td></tr><tr><td valign="top"><a href="#setopts-2">setopts/2</a></td><td>Change options for the metric.</td></tr><tr><td valign="top"><a href="#start-0">start/0</a></td><td>Start exometer and dependent apps (for testing).</td></tr><tr><td valign="top"><a href="#stop-0">stop/0</a></td><td>Stop exometer and dependent apps (for testing).</td></tr><tr><td valign="top"><a href="#update-2">update/2</a></td><td>Update the given metric with <code>Value</code>.</td></tr><tr><td valign="top"><a href="#update_or_create-2">update_or_create/2</a></td><td>Update existing metric, or create+update according to template.</td></tr><tr><td valign="top"><a href="#update_or_create-4">update_or_create/4</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#aggregate-2">aggregate/2</a></td><td>Aggregate datapoints of matching entries.</td></tr><tr><td valign="top"><a href="#create_entry-1">create_entry/1</a></td><td></td></tr><tr><td valign="top"><a href="#delete-1">delete/1</a></td><td>Delete the metric.</td></tr><tr><td valign="top"><a href="#ensure-3">ensure/3</a></td><td>Ensure that metric exists and is of given type.</td></tr><tr><td valign="top"><a href="#find_entries-1">find_entries/1</a></td><td>Find metrics based on a name prefix pattern.</td></tr><tr><td valign="top"><a href="#get_value-1">get_value/1</a></td><td>Fetch the current value of the metric.</td></tr><tr><td valign="top"><a href="#get_value-2">get_value/2</a></td><td></td></tr><tr><td valign="top"><a href="#get_values-1">get_values/1</a></td><td></td></tr><tr><td valign="top"><a href="#info-1">info/1</a></td><td>Returns a list of info items for Metric, see <a href="#info-2"><code>info/2</code></a>.</td></tr><tr><td valign="top"><a href="#info-2">info/2</a></td><td>Retrieves information about a metric.</td></tr><tr><td valign="top"><a href="#new-2">new/2</a></td><td>Equivalent to <a href="#new-3"><tt>new(Name, Type, [])</tt></a>.</td></tr><tr><td valign="top"><a href="#new-3">new/3</a></td><td>Create a new metrics entry.</td></tr><tr><td valign="top"><a href="#propose-3">propose/3</a></td><td>Propose a new exometer entry (no entry actually created).</td></tr><tr><td valign="top"><a href="#re_register-3">re_register/3</a></td><td>Create a new metrics entry, overwrite any old entry.</td></tr><tr><td valign="top"><a href="#register_application-0">register_application/0</a></td><td>Equivalent to <a href="#register_application-1"><tt>register_application(current_application())</tt></a>.</td></tr><tr><td valign="top"><a href="#register_application-1">register_application/1</a></td><td>Registers statically defined entries with exometer.</td></tr><tr><td valign="top"><a href="#reset-1">reset/1</a></td><td>Reset the metric.</td></tr><tr><td valign="top"><a href="#sample-1">sample/1</a></td><td>Tells the metric (mainly probes) to take a sample.</td></tr><tr><td valign="top"><a href="#select-1">select/1</a></td><td>Perform an <code>ets:select()</code> on the set of metrics.</td></tr><tr><td valign="top"><a href="#select-2">select/2</a></td><td>Perform an <code>ets:select()</code> with a Limit on the set of metrics.</td></tr><tr><td valign="top"><a href="#select_cont-1">select_cont/1</a></td><td>Equivalent to <a href="ets.md#select-1"><tt>ets:select(Cont)</tt></a>.</td></tr><tr><td valign="top"><a href="#select_count-1">select_count/1</a></td><td>Corresponds to <a href="ets.md#select_count-1"><code>ets:select_count/1</code></a>.</td></tr><tr><td valign="top"><a href="#setopts-2">setopts/2</a></td><td>Change options for the metric.</td></tr><tr><td valign="top"><a href="#start-0">start/0</a></td><td>Start exometer and dependent apps (for testing).</td></tr><tr><td valign="top"><a href="#stop-0">stop/0</a></td><td>Stop exometer and dependent apps (for testing).</td></tr><tr><td valign="top"><a href="#update-2">update/2</a></td><td>Update the given metric with <code>Value</code>.</td></tr><tr><td valign="top"><a href="#update_or_create-2">update_or_create/2</a></td><td>Update existing metric, or create+update according to template.</td></tr><tr><td valign="top"><a href="#update_or_create-4">update_or_create/4</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
@@ -425,6 +425,13 @@ SNMP type for a given data point. `SYNTAX` needs to be a binary or a string,
 and corresponds to the SYNTAX definition in the generated SNMP MIB.
 
 
+
+* `{'--', Keys}` removes option keys from the applied template.
+This can be used to clean up the options list when overriding the defaults
+for a given namespace (if the default definition contains options that are
+not applicable, or would even cause problems with the current entry.)
+
+
 For example, the default value for an exometer counter is `"Counter32"`, which
 expands to `SYNTAX Counter32` in the corresponding MIB object definition. If
 a 64-bit counter (not supported by SNMPv1) is desired instead, the option
@@ -432,6 +439,24 @@ a 64-bit counter (not supported by SNMPv1) is desired instead, the option
 (note that `value` in this case is the name of the data point representing
 the counter value).
 
+<a name="propose-3"></a>
+
+### propose/3 ###
+
+
+<pre><code>
+propose(Name::<a href="#type-name">name()</a>, Type::<a href="#type-type">type()</a>, Opts::<a href="#type-options">options()</a>) -&gt; <a href="exometer_info.md#type-pp">exometer_info:pp()</a> | <a href="#type-error">error()</a>
+</code></pre>
+<br />
+
+
+Propose a new exometer entry (no entry actually created).
+
+
+This function analyzes a proposed entry definition, applying templates
+and processing options in the same way as [`new/3`](#new-3), but not actually
+creating the entry. The return value, if successful, corresponds to
+`exometer_info:pp(Entry)`.
 <a name="re_register-3"></a>
 
 ### re_register/3 ###

--- a/doc/exometer_admin.md
+++ b/doc/exometer_admin.md
@@ -11,7 +11,7 @@ __Behaviours:__ [`gen_server`](gen_server.md).
 
 
 <table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#auto_create_entry-1">auto_create_entry/1</a></td><td></td></tr><tr><td valign="top"><a href="#code_change-3">code_change/3</a></td><td></td></tr><tr><td valign="top"><a href="#delete_entry-1">delete_entry/1</a></td><td></td></tr><tr><td valign="top"><a href="#demonitor-1">demonitor/1</a></td><td></td></tr><tr><td valign="top"><a href="#ensure-3">ensure/3</a></td><td></td></tr><tr><td valign="top"><a href="#find_auto_template-1">find_auto_template/1</a></td><td>Convenience function for testing which template will apply to
-<code>Name</code>.</td></tr><tr><td valign="top"><a href="#handle_call-3">handle_call/3</a></td><td></td></tr><tr><td valign="top"><a href="#handle_cast-2">handle_cast/2</a></td><td></td></tr><tr><td valign="top"><a href="#handle_info-2">handle_info/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-1">init/1</a></td><td></td></tr><tr><td valign="top"><a href="#load_defaults-0">load_defaults/0</a></td><td></td></tr><tr><td valign="top"><a href="#load_predefined-0">load_predefined/0</a></td><td></td></tr><tr><td valign="top"><a href="#make_patterns-2">make_patterns/2</a></td><td></td></tr><tr><td valign="top"><a href="#monitor-2">monitor/2</a></td><td></td></tr><tr><td valign="top"><a href="#new_entry-3">new_entry/3</a></td><td></td></tr><tr><td valign="top"><a href="#normalize_name-1">normalize_name/1</a></td><td></td></tr><tr><td valign="top"><a href="#prefixes-1">prefixes/1</a></td><td></td></tr><tr><td valign="top"><a href="#preset_defaults-0">preset_defaults/0</a></td><td></td></tr><tr><td valign="top"><a href="#re_register_entry-3">re_register_entry/3</a></td><td></td></tr><tr><td valign="top"><a href="#register_application-1">register_application/1</a></td><td></td></tr><tr><td valign="top"><a href="#set_default-3">set_default/3</a></td><td>Sets a default definition for a metric type, possibly using wildcards.</td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr><tr><td valign="top"><a href="#terminate-2">terminate/2</a></td><td></td></tr></table>
+<code>Name</code>.</td></tr><tr><td valign="top"><a href="#handle_call-3">handle_call/3</a></td><td></td></tr><tr><td valign="top"><a href="#handle_cast-2">handle_cast/2</a></td><td></td></tr><tr><td valign="top"><a href="#handle_info-2">handle_info/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-1">init/1</a></td><td></td></tr><tr><td valign="top"><a href="#load_defaults-0">load_defaults/0</a></td><td></td></tr><tr><td valign="top"><a href="#load_predefined-0">load_predefined/0</a></td><td></td></tr><tr><td valign="top"><a href="#make_patterns-2">make_patterns/2</a></td><td></td></tr><tr><td valign="top"><a href="#monitor-2">monitor/2</a></td><td></td></tr><tr><td valign="top"><a href="#new_entry-3">new_entry/3</a></td><td></td></tr><tr><td valign="top"><a href="#normalize_name-1">normalize_name/1</a></td><td></td></tr><tr><td valign="top"><a href="#prefixes-1">prefixes/1</a></td><td></td></tr><tr><td valign="top"><a href="#preset_defaults-0">preset_defaults/0</a></td><td></td></tr><tr><td valign="top"><a href="#propose-3">propose/3</a></td><td></td></tr><tr><td valign="top"><a href="#re_register_entry-3">re_register_entry/3</a></td><td></td></tr><tr><td valign="top"><a href="#register_application-1">register_application/1</a></td><td></td></tr><tr><td valign="top"><a href="#set_default-3">set_default/3</a></td><td>Sets a default definition for a metric type, possibly using wildcards.</td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr><tr><td valign="top"><a href="#terminate-2">terminate/2</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
@@ -147,6 +147,13 @@ Convenience function for testing which template will apply to
 ### preset_defaults/0 ###
 
 `preset_defaults() -> any()`
+
+
+<a name="propose-3"></a>
+
+### propose/3 ###
+
+`propose(Name, Type, Opts) -> any()`
 
 
 <a name="re_register_entry-3"></a>

--- a/src/exometer.erl
+++ b/src/exometer.erl
@@ -44,6 +44,7 @@
    [
     new/2, new/3,
     re_register/3, ensure/3,
+    propose/3,
     update/2, update_or_create/2, update_or_create/4,
     get_value/1, get_value/2, get_values/1,
     sample/1,
@@ -127,6 +128,11 @@ new(Name, Type) ->
 %% SNMP type for a given data point. `SYNTAX' needs to be a binary or a string,
 %% and corresponds to the SYNTAX definition in the generated SNMP MIB.
 %%
+%% * <code>{'--', Keys}</code> removes option keys from the applied template.
+%% This can be used to clean up the options list when overriding the defaults
+%% for a given namespace (if the default definition contains options that are
+%% not applicable, or would even cause problems with the current entry.)
+%%
 %% For example, the default value for an exometer counter is `"Counter32"', which
 %% expands to `SYNTAX Counter32' in the corresponding MIB object definition. If
 %% a 64-bit counter (not supported by SNMPv1) is desired instead, the option
@@ -137,6 +143,17 @@ new(Name, Type) ->
 %% @end
 new(Name, Type, Opts) when is_list(Name), is_list(Opts) ->
     exometer_admin:new_entry(Name, Type, Opts).
+
+-spec propose(name(), type(), options()) -> exometer_info:pp() | error().
+%% @doc Propose a new exometer entry (no entry actually created).
+%%
+%% This function analyzes a proposed entry definition, applying templates
+%% and processing options in the same way as {@link new/3}, but not actually
+%% creating the entry. The return value, if successful, corresponds to
+%% `exometer_info:pp(Entry)'.
+%% @end
+propose(Name, Type, Opts) when is_list(Name), is_list(Opts) ->
+    exometer_admin:propose(Name, Type, Opts).
 
 -spec re_register(name(), type(), options()) -> ok.
 %% @doc Create a new metrics entry, overwrite any old entry.

--- a/src/exometer_info.erl
+++ b/src/exometer_info.erl
@@ -28,6 +28,8 @@
 -include("exometer.hrl").
 -include_lib("parse_trans/include/exprecs.hrl").
 
+-export_type([pp/0]).
+
 -export_records([exometer_entry]).
 
 -type pp() :: {atom(), [{atom(), any()}]}.

--- a/src/exometer_probe.erl
+++ b/src/exometer_probe.erl
@@ -518,6 +518,9 @@ loop(St) ->
 handle_msg(Msg, St) ->
     Module = St#st.module,
     case Msg of
+	{system, From, Req} ->
+	    exometer_proc:handle_system_msg(
+	      Req, From, St, fun(St1) -> loop(St1) end);
         {exometer_proc, {From, Ref}, {get_value, default} } ->
             {ok, DataPoints} = Module:probe_get_datapoints(St#st.mod_state),
             {Reply, NSt} =


### PR DESCRIPTION
- When creating a new entry redefining a default definition, options
  replace default options with the same key.
- The special option {'--', Keys} removes given option keys from the
  default specification.
- Added 'sys' message handling to exometer_proc, which means that
  `sys:get_status(exometer:info(Probe, ref))` will work.
