### PR TITLE
Write gauges by default in statsd.

### DIFF
--- a/src/exometer_report_statsd.erl
+++ b/src/exometer_report_statsd.erl
@@ -62,22 +62,17 @@ exometer_report(Metric, DataPoint, Extra, Value, #st{type_map = TypeMap} = St) -
     Key = ets_key(Metric, DataPoint),
     Name = name(Metric, DataPoint),
     ?debug("Report metric ~p = ~p~n", [Name, Value]),
-    case exometer_util:report_type(Key, Extra, TypeMap) of
-        {ok, Type} ->
-            Line = [Name, ":", value(Value), "|", type(Type)],
-            case gen_udp:send(St#st.socket, St#st.address, St#st.port, Line) of
-                ok ->
-                    {ok, St};
-                {error, Reason} ->
-                    ?info("Unable to write metric. ~p~n", [Reason]),
-                    {ok, St}
-            end;
-        error ->
-	    ?warning(
-	       "Could not resolve ~p to a statsd type."
-	       "Update exometer_report_statsd -> type_map in app.config. "
-	       "Value lost~n", [Key]),
-	    {ok, St}
+    Type = case exometer_util:report_type(Key, Extra, TypeMap) of
+               {ok, T} -> T;
+               error -> gauge
+           end,
+    Line = [Name, ":", value(Value), "|", type(Type)],
+    case gen_udp:send(St#st.socket, St#st.address, St#st.port, Line) of
+        ok ->
+            {ok, St};
+        {error, Reason} ->
+            ?info("Unable to write metric. ~p~n", [Reason]),
+            {ok, St}
     end.
 
 exometer_subscribe(_Metric, _DataPoint, _Extra, _Interval, St) ->


### PR DESCRIPTION
If a metric is not found to have a value in type map previously the
metric would be lost. This is a slightly unintuitive behaviour with
regard to the statsd reporter. Prefer instead to ship the untyped as
gauges, which has value in a statsd context.

Signed-off-by: Brian L. Troutwine brian.troutwine@adroll.com
