### PR TITLE
improved package management

### DIFF
--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -65,6 +65,7 @@ with ``exometer''.
 6. {@section Creating custom exometer entries}
 7. {@section Creating custom probes}
 8. {@section Creating custom reporter plugins}
+9. {@section Dependency management}
 
 == Concepts and Definitions ==
 
@@ -375,8 +376,8 @@ The data sent to OpenTSDB will be formatted as follows:
 
 <pre>put metric timestamp value host=host type=datapoint</pre>
 
-Where the value for the host tag will be the configured host in the reporter 
-configuration (defaults to the value returned by `netadm:localhost'), and 
+Where the value for the host tag will be the configured host in the reporter
+configuration (defaults to the value returned by `netadm:localhost'), and
 datapoint tags as specified by the subscriber.
 
 Please see {@section Configuring opentsdb reporter} for details on the
@@ -857,7 +858,7 @@ The following attributes are available for configuration:
     seconds.
 
 + `connect_timeout' (milliseconds - default: 5000)
-     <br/>Specifies how long the opentsdb reporter plugin shall wait for a 
+     <br/>Specifies how long the opentsdb reporter plugin shall wait for a
     socket connection to complete before timing out. A timed out
     connection attempt will be retried after the reconnect interval has
     passed see item 1 above).
@@ -946,3 +947,41 @@ Please see @see exometer_probe documentation for details.
 
 == Creating custom reporter plugins ==
 Please see @see exometer_report documentation for details.
+
+== Dependency management ==
+Exometer dependencies can be controlled using the `EXOMETER_PACKAGES'
+unix environment variable: a string listing packages or applications to
+either keep or remove, separated using space, tab or comma.
+
+Syntax:
+
++ `(Package)' - use `Package' as a base. This will implicitly exclude all
+  applications not included in `Package'. See below for supported packages.
+
++ `+(Package)' - add applications included in `Package'.
+
++ `-(Package)' - remove applications in `Package' (except mandatory deps).
+
++ `App' - keep application `App'.
+
++ `+App' - keep application `App'.
+
++ `-App' - exclude application `App'.
+
+Supported packages:
+
++ `minimal' - only the mandatory deps: `lager', `parse_trans', `setup'.
+
++ `basic' - (mandatory deps and) `folsom'.
+
++ `amqp' - (mandatory deps and) `amqp_client`, `jiffy'.
+
++ `full' - all of the above, plus `afunix' and `netlink'.
+
+Example - use only basic deps plus `afunix'
+
+```EXOMETER_PACKAGES="(basic), +afunix" make'''
+
+Example - use all deps except the AMQP-related deps:
+
+```export EXOMETER_PACKAGES="(full) -(amqp)"'''

--- a/priv/check_packages.script
+++ b/priv/check_packages.script
@@ -5,22 +5,96 @@
 %% This Source Code Form is subject to the terms of the Mozilla Public                                    %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at http://mozilla.org/MPL/2.0/.                                               %%                                                                                                        %%---- END COPYRIGHT ---------------------------------------------------------
 
+Configs0 = proplists:get_value(configurations, CONFIG, []).
+{_, Mandatory0} = lists:keyfind(mandatory_deps, 1, CONFIG).
+Mandatory = ordsets:from_list(Mandatory0).
+Expand = fun(C, Exp) when is_list(C) ->
+		 R = lists:foldl(fun({Cfg}, Acc) ->
+				     CVal = proplists:get_value(
+					      Cfg, Configs0, []),
+				     ordsets:union(
+				       Acc,
+				       ordsets:from_list(Exp(CVal, Exp)));
+				(App, Acc) when is_atom(App) ->
+				     ordsets:add_element(App, Acc);
+				(Other, Acc) ->
+				     Acc
+				 end, Mandatory, C),
+		 R;
+	    (C, Exp) -> Exp([C], Exp)
+	 end.
+Configs = [{K, Expand(V, Expand)} || {K,V} <- Configs0].
+{_, Deps} = lists:keyfind(deps, 1, CONFIG).
+Unpar = fun(Name) -> ")" ++ Rev = lists:reverse(Name),
+		     list_to_existing_atom(lists:reverse(Rev))
+	end.
+EnsureApp = fun(A, As) ->
+		    case lists:member(A, As) of
+			true -> As;
+			false ->
+			    case lists:keymember(A, 1, Deps) of
+				false -> As;
+				true  -> [A|As]
+			    end
+		    end
+	    end.
+DelApp = fun(A, As) ->
+		 case lists:member(A, Mandatory) of
+		     false ->
+			 [A1 || A1 <- As, A1 =/= A];
+		     true ->
+			 As
+		 end
+	 end.
 case os:getenv("EXOMETER_PACKAGES") of
     Str when is_list(Str) ->
 	L = string:tokens(Str, "\t, \n"),
-	{_, Deps} = lists:keyfind(deps, 1, CONFIG),
-	Deps1 = lists:filter(
-		  fun(D) when is_tuple(D) ->
-			  App = element(1,D),
-			  AppStr = atom_to_list(App),
-			  case lists:member(AppStr, L) orelse
-			      lists:member("+" ++ AppStr, L) of
-			      false ->
-				  not lists:member("-" ++ AppStr, L);
-			      true ->
-				  true
-			  end
-		  end, Deps),
+	Deps1 =
+	    try As = lists:foldl(
+		       fun("(" ++ P, Acc) ->
+			       Apps = Expand({Unpar(P)}, Expand),
+			       lists:foldl(fun(A, Acc1) ->
+						   EnsureApp(A, Acc1)
+					   end, Acc, Apps);
+			  ("+(" ++ P, Acc) ->
+			       %% Same as above
+			       Apps = Expand({Unpar(P)}, Expand),
+			       lists:foldl(fun(A, Acc1) ->
+						   EnsureApp(A, Acc1)
+					   end, Acc, Apps);
+			  ("-(" ++ P, Acc) ->
+			       Apps = Expand({Unpar(P)}, Expand),
+			       lists:foldl(fun(A, Acc1) ->
+						   DelApp(A, Acc1)
+					   end, Acc, Apps);
+			  ("-" ++ AppStr, Acc) ->
+			       try A = list_to_existing_atom(AppStr),
+				     DelApp(A, Acc)
+			       catch
+				   error:_ -> Acc
+			       end;
+			  ("+" ++ AppStr, Acc) ->
+			       try A = list_to_existing_atom(AppStr),
+				     EnsureApp(A, Acc)
+			       catch
+				   error:_ -> Acc
+			       end;
+			  (AppStr, Acc) ->
+			       try A = list_to_existing_atom(AppStr),
+				     EnsureApp(A, Acc)
+			       catch
+				   error:_ -> Acc
+			       end
+		       end, [], L),
+		 lists:filter(fun(D) ->
+				      lists:member(element(1,D), As)
+			      end, Deps)
+	    catch
+		error:Err ->
+		    io:fwrite("Caught ~p~nT = ~p~n",
+			      [Err, erlang:get_stacktrace()]),
+		    Deps
+	    end,
 	lists:keyreplace(deps, 1, CONFIG, {deps, Deps1});
     false ->
 	CONFIG

--- a/rebar.config
+++ b/rebar.config
@@ -8,6 +8,11 @@
   "EXOMETER-MIB.mib"
  ]}.
 
+{mandatory_deps, [lager , parse_trans, setup]}.
+{configurations, [{minimal, []},
+		  {basic, [folsom]},
+		  {amqp , [amqp_client, jiffy]},
+		  {full , [{basic}, afunix, netlink, {amqp}]}]}.
 {deps,
  [
   {lager, ".*", {git, "git://github.com/basho/lager.git", {tag,"master"}}},


### PR DESCRIPTION
From overview.edoc:

== Dependency management ==
Exometer dependencies can be controlled using the `EXOMETER_PACKAGES`
unix environment variable: a string listing packages or applications to
either keep or remove, separated using space, tab or comma.

Syntax:
- `(Package)` - use `Package` as a base. This will implicitly exclude all
  applications not included in `Package`. See below for supported packages.
- `+(Package)` - add applications included in `Package`.
- `-(Package)` - remove applications in `Package' (except mandatory deps).
- `App` - keep application `App`.
- `+App` - keep application `App`.
- `-App` - exclude application `App`.

Supported packages:
- `minimal` - only the mandatory deps: `lager`, `parse_trans`, `setup`.
- `basic` - (mandatory deps and) `folsom`.
- `amqp` - (mandatory deps and) `amqp_client`, `jiffy`.
- `full` - all of the above, plus `afunix` and `netlink`.

Example - use only basic deps plus `afunix`

```
EXOMETER_PACKAGES="(basic), +afunix" make
```

Example - use all deps except the AMQP-related deps:

```
export EXOMETER_PACKAGES="(full) -(amqp)"
```
