### PR TITLE
add wrap_counter type

### DIFF
--- a/src/exometer_admin.erl
+++ b/src/exometer_admin.erl
@@ -477,6 +477,7 @@ exometer_default(Name, Type) ->
 module(counter )      -> exometer;
 module(gauge)         -> exometer;
 module(fast_counter)  -> exometer;
+module(wrap_counter)  -> exometer;
 module(uniform)       -> exometer_uniform;
 module(duration)      -> exometer_duration;
 module(histogram)     -> exometer_histogram;

--- a/src/exometer_util.erl
+++ b/src/exometer_util.erl
@@ -295,6 +295,7 @@ key_match(_, _)   -> false.
 get_datapoints(#exometer_entry{module = exometer,
 			       type = T}) when T==counter;
                                                T==fast_counter;
+					       T==wrap_counter;
                                                T==gauge ->
     [value, ms_since_reset];
 get_datapoints(#exometer_entry{behaviour = entry,


### PR DESCRIPTION
Feedback wanted.

Wrapping counters are sometimes useful (e.g. expected in SNMP). This PR adds a `wrap_counter` type (docs not yet updated), where the `{wrap, {Min, Max}}` option provides a range.

To discuss:
* Another option would be to extend the `counter` type.
* What should the initial value be? Separately specified? Currently, initial value is `0`, which is also what the counter resets to.

Example:
```erlang
15:21:42.136 [info] Application exometer started on node nonode@nohost
2> exometer:new([c], wrap_counter, [{wrap,{0,4}}]).
ok
3> exometer:update([c],1).
ok
4> exometer:get_value([c]).
{ok,[{value,1},{ms_since_reset,10727}]}
5> [begin exometer:update([c],1), exometer:get_value([c],value) end || _ <- lists:seq(1,10)].
[{ok,[{value,2}]},
 {ok,[{value,3}]},
 {ok,[{value,4}]},
 {ok,[{value,0}]},
 {ok,[{value,1}]},
 {ok,[{value,2}]},
 {ok,[{value,3}]},
 {ok,[{value,4}]},
 {ok,[{value,0}]},
 {ok,[{value,1}]}]
6> exometer:reset([c]).
ok
7> exometer:get_value([c]).                                                                  
{ok,[{value,0},{ms_since_reset,2799}]}
```