### PR TITLE
add value16, value32, value64 datapoints to counter

### DIFF
--- a/src/exometer.erl
+++ b/src/exometer.erl
@@ -1017,12 +1017,21 @@ type_arg_first(Opts) ->
 %% Retrieve individual data points for the counter maintained by
 %% the exometer record itself.
 get_ctr_datapoint(#exometer_entry{name = Name}, value) ->
-    {value, lists:sum([ets:lookup_element(T, Name, #exometer_entry.value)
-		       || T <- exometer_util:tables()])};
+    {value, counter_sum(Name)};
+get_ctr_datapoint(#exometer_entry{name = Name}, value16) ->
+    {value, counter_sum(Name) rem 16#FFFF};
+get_ctr_datapoint(#exometer_entry{name = Name}, value32) ->
+    {value, counter_sum(Name) rem 16#FFFFFFFF};
+get_ctr_datapoint(#exometer_entry{name = Name}, value64) ->
+    {value, counter_sum(Name) rem 16#FFFFFFFFFFFFFFFF};
 get_ctr_datapoint(#exometer_entry{timestamp = TS}, ms_since_reset) ->
     {ms_since_reset, exometer_util:timestamp() - TS};
 get_ctr_datapoint(#exometer_entry{}, Undefined) ->
     {Undefined, undefined}.
+
+counter_sum(Name) ->
+    lists:sum([ets:lookup_element(T, Name, #exometer_entry.value)
+	       || T <- exometer_util:tables()]).
 
 get_gauge_datapoint(#exometer_entry{value = Value}, value) ->
     {value, Value};


### PR DESCRIPTION
Alternative solution for wrapping counters. The datapoints value16, value32, value64 are supported by regular counters, but don't show up in the default list of datapoints.

```erlang
17:00:31.573 [info] Application exometer started on node nonode@nohost
2> exometer:new([c], counter, []).
ok
3> exometer:update([c], 4294967290).
ok
4> [begin exometer:update([c], 1), exometer:get_value([c], value32) end || _ <- lists:seq(1,10)].
[{ok,[{value,4294967291}]},
 {ok,[{value,4294967292}]},
 {ok,[{value,4294967293}]},
 {ok,[{value,4294967294}]},
 {ok,[{value,0}]},
 {ok,[{value,1}]},
 {ok,[{value,2}]},
 {ok,[{value,3}]},
 {ok,[{value,4}]},
 {ok,[{value,5}]}]
```