### PR TITLE
Change folsom source and version for R17 compat

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,7 @@
   {parse_trans, ".*", {git, "git://github.com/uwiger/parse_trans.git", {tag,"2.9"}}},
   {afunix, ".*", {git, "https://github.com/tonyrog/afunix.git", {tag,"1.0"}}},
   {netlink, ".*", {git, "git://github.com/Feuerlabs/netlink.git", {tag,"1.0"}}},
-  {folsom, ".*", {git, "git://github.com/basho/folsom", {tag, "0.7.4p4"}}},
+  {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.8.1"}}},
   {amqp_client, ".*", {git, "git://github.com/jbrisbin/amqp_client.git", {tag, "rabbitmq-3.3.5"}}},
   {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.13.3"}},
   {setup, ".*", {git, "git://github.com/uwiger/setup.git", {tag,"1.4"}}}


### PR DESCRIPTION
New version of folsom is needed for new version of meck for R17 compatibility.
- Update the source of folsom to the boundary/folsom (basho repo is outdated)
- Update version of folsom to 0.8.1
