### PR TITLE
Force to reconnect when socket is not connected

### DIFF
--- a/src/exometer_report_collectd.erl
+++ b/src/exometer_report_collectd.erl
@@ -290,6 +290,12 @@ send_request(Sock, Request, Metric, DataPoint, Extra, Value,
                     maybe_reconnect_after(Sock),
                     St#st{socket = undefined}
             end;
+        {error, enotconn} ->
+            %% Socket is not connected, setup later reconnect
+            ?warning("Failed to send. Will reconnect in ~p~n",
+                     [St#st.reconnect_interval]),
+            maybe_reconnect_after(Sock),
+            St#st{socket = undefined};
         _ ->
             St
     catch


### PR DESCRIPTION
The call `affix:send/2` may return `{error, enotconn}` when socket is disconnected (coming straight from `prim_inet/send/2`). 

`exometer_report_collectd` ignores that possible error and continuously tries to push metrics without attempting to reconnect. This case clause aims to amend that problem, forcing the reporter to reconnect.

