### PR TITLE
Fix exometer application dependencies

### DIFF
--- a/src/exometer.app.src
+++ b/src/exometer.app.src
@@ -8,7 +8,8 @@
    [
     kernel,
     stdlib,
-    lager
+    lager,
+    exometer_core
    ]},
   {included_applications,
    [


### PR DESCRIPTION
Without this line the application didn't start by only typing `application:ensure_all_started(exometer)`, but needed also `application:ensure_all_started(exometer_core)`.