### PR TITLE
Histogram subscription assumed its metrics were atoms, when many of them are numbers

### DIFF
--- a/src/exometer_report_opentsdb.erl
+++ b/src/exometer_report_opentsdb.erl
@@ -103,7 +103,7 @@ exometer_report(_Metric, _DataPoint, _Extra, _Value, St) when St#st.socket =:= u
 exometer_report(Metric, DataPoint, _Extra, Value, #st{socket = Sock, hostname = Hostname} = St) ->
     Line = [
         "put ", name(Metric), " ", timestamp(), " ", value(Value), " ",
-        "hostname=", Hostname, " ", "type=", atom_to_list(DataPoint), $\n
+        "hostname=", Hostname, " ", "type=", metric_elem_to_list(DataPoint), $\n
     ],
     case gen_tcp:send(Sock, Line) of
         ok ->


### PR DESCRIPTION
Histograms would crash when subscribing to `exometer_report_opentsdb`, since their metric names are ints. 