### PR TITLE
Add prefix option to statsd reporter

### DIFF
--- a/src/exometer_report_statsd.erl
+++ b/src/exometer_report_statsd.erl
@@ -36,7 +36,7 @@
 -record(st, {socket  :: inet:socket(),
              address :: inet:ip_address(),
              port    :: inet:port_number(),
-	     prefix  :: string(),
+             prefix  :: string(),
              type_map :: [{list(atom()), atom()}]}).
 
 %%%===================================================================
@@ -55,7 +55,7 @@ exometer_init(Opts) ->
     case gen_udp:open(0, [AddrType]) of
 	{ok, Sock} ->
 	    {ok, #st{socket=Sock, address=IP, port=Port, type_map=TypeMap,
-		     prefix = Prefix}};
+		     prefix=Prefix}};
 	{error, _} = Error ->
 	    Error
     end.
@@ -121,11 +121,11 @@ type(meter) -> "m";
 type(set) -> "s". %% datadog specific type, see http://docs.datadoghq.com/guides/dogstatsd/#tags
 
 ets_key([] , Metric, DataPoint) -> Metric ++ [ DataPoint ];
-ets_key(Pfx, Metric, DataPoint) -> [Pfx|Metric] ++ [DataPoint].
+ets_key(Pfx, Metric, DataPoint) -> [ Pfx | Metric ] ++ [ DataPoint ].
 
 name(Prefix, Metric, DataPoint) ->
     intersperse(".", lists:map(fun thing_to_list/1,
-			       ets_key(Prefix, Metric, DataPoint))).
+                               ets_key(Prefix, Metric, DataPoint))).
 
 thing_to_list(X) when is_atom(X) -> atom_to_list(X);
 thing_to_list(X) when is_integer(X) -> integer_to_list(X);


### PR DESCRIPTION
Example (using a reporter logger that I will push to exometer_core shortly):

```erlang
4> exometer_report:add_reporter(statsd,[{module,exometer_report_statsd},{host,"localhost"},{port,8888},{prefix,"ulf"}]).
ok
5> 19:11:39.348 [info] exometer_report_statsd([{module,exometer_report_statsd},{host,"localhost"},{port,8888},{prefix,"ulf"}]): Starting

5> exometer_report:subscribe(statsd,{find,['_']},value,10000,true).
ok
6> ulf.g.value:0|g
ulf.g.value:0|g
ulf.g.value:0|g
```

As far as I can tell, this is similar to how e.g. the Python Statsd client works.