### PR TITLE
Sync OTP version for Travis with exometer_core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ sudo: false
 language: erlang
 script: "make ci"
 otp_release:
+    - 18.2.1
+    - 18.2
+    - 18.1
+    - 18.0
+    - 17.5
     - 17.4
     - 17.3
     - 17.1
     - 17.0
     - R16B03-1
-    - R16B03
-    - R16B02
-    - R16B01
-    - R16B
 after_failure: "echo 'logs/raw.log\n'; cat logs/raw.log; for f in `find logs/ct_run*/log*/ -type f`; do echo \"\n$f\n\" ; cat $f; done"


### PR DESCRIPTION
I'd like to merge this before fixing OTP 18.x support. 