### PR TITLE
Allow configuring Statsd host and port from env vars

### DIFF
--- a/src/exometer_report_statsd.erl
+++ b/src/exometer_report_statsd.erl
@@ -45,10 +45,10 @@
 
 exometer_init(Opts) ->
     ?info("~p(~p): Starting~n", [?MODULE, Opts]),
-    {ok, Host} = inet:gethostbyname(get_opt(hostname, Opts, ?DEFAULT_HOST)),
+    {ok, Host} = inet:gethostbyname(host(Opts)),
     [IP|_]     = Host#hostent.h_addr_list,
     AddrType   = Host#hostent.h_addrtype,
-    Port       = get_opt(port, Opts, ?DEFAULT_PORT),
+    Port       = port(Opts),
     TypeMap    = get_opt(type_map, Opts, []),
     Prefix     = get_opt(prefix, Opts, []),
 
@@ -112,6 +112,26 @@ exometer_terminate(_, _) ->
 
 get_opt(K, Opts, Def) ->
     exometer_util:get_opt(K, Opts, Def).
+
+host(Opts) ->
+  case get_opt(hostname, Opts, ?DEFAULT_HOST) of
+    {system, T} -> from_env(T);
+    T -> T
+  end.
+
+port(Opts) ->
+  case get_opt(port, Opts, ?DEFAULT_PORT) of
+    {system, T} ->
+      {String, _} = string:to_integer(from_env(T)),
+      String;
+    T -> T
+  end.
+
+from_env(Config) ->
+  case os:getenv(Config) of
+    false -> nil;
+    V -> V
+  end.
 
 type(gauge) -> "g";
 type(counter) -> "c";


### PR DESCRIPTION
This PR changes `exometer_report_statsd` to be configurable from environmental variables.

It can be configured as follows (Elixir code):

```elixir
config :exometer,
  report: [
    reporters: [
      {:exometer_report_statsd, [hostname: {:system, "STATSD_HOST"}, port: {:system, "STATSD_PORT"}]}
    ]
  ]
```

The goal is to build the release artefact using a tool like Distillery just once for multiple environments (staging / production) and supply all the required configuration via env vars.

If this behaviour is decided to be merged, I can also work on the other reporters.