### PR TITLE
Fix reporting openTSDB metrics with binary elements in name

### DIFF
--- a/src/exometer_report_opentsdb.erl
+++ b/src/exometer_report_opentsdb.erl
@@ -226,5 +226,8 @@ metric_elem_to_list(E) when is_atom(E) ->
 metric_elem_to_list(E) when is_list(E) ->
     E;
 
+metric_elem_to_list(E) when is_binary(E) ->
+    [E];
+
 metric_elem_to_list(E) when is_integer(E) ->
     integer_to_list(E).


### PR DESCRIPTION
Same idea as https://github.com/Feuerlabs/exometer_core/commit/1d07e40595878fe3a500b02fabd20130ab6738f9

There's a crash that happens when trying to report openTSDB metrics if the metric name is a binary.